### PR TITLE
fix zcash mini config command

### DIFF
--- a/config/rofi/blockchain.txt
+++ b/config/rofi/blockchain.txt
@@ -4,4 +4,4 @@
 Bitcoin|bitcoin-qt.desktop|
 Monero|monero-wallet-gui.desktop|
 GlyphRiot|alacritty --class glyphriot --title "GlyphRiot" -e sh -c '$HOME/.local/bin/glyphriot --prompt; stty sane 2>/dev/null; printf "\n\nPress Enter to close... "; read -r _'|
-ZCash Mini|alacritty --class zcashmini --title "ZCash Mini" -e sh -c '$HOME/.local/bin/zcashmini; printf "\n\nPress Enter to close... "; read -r _'|󰬡
+ZCash Mini|alacritty --class zcashmini --title "ZCash Mini" -e sh -c '$HOME/.local/bin/zcash-mini; printf "\n\nPress Enter to close... "; read -r _'|󰬡


### PR DESCRIPTION
the missing dash caused the command to fail from the rofi menu